### PR TITLE
Add "Linux and Beyond" session README under Club Services

### DIFF
--- a/Club Services/Linux and Beyond/README.md
+++ b/Club Services/Linux and Beyond/README.md
@@ -1,0 +1,22 @@
+# Topic: Basic Linux
+
+---
+
+## Overview
+
+The session started with the basics of Open Source and Linux, along with different Linux distributions and desktop environments. Also covered the different ways of experiencing linux, i.e. via Dual Booting and using a VM. Deeply explained the CLI and how it differs from the GUI. Participants were taught basic commands such as ls, cd, pwd, man, and cat, along with fun commands like cmatrix and neofetch.
+A hands-on lab was also conducted on TryHackMe, giving the participants a practical overview with Linux commands and how it works.
+
+---
+
+## Presenters:
+- [Jatin Vishwakarma](https://github.com/coddingjatin)
+- [Riya Dey](https://github.com/riyadey27)
+- [Piyush Gogi](https://github.com/piush365)
+
+---
+
+## Date
+**29th Nov 2025**
+
+---


### PR DESCRIPTION
Added a new folder "Club Services/Linux and Beyond" with the session README for "Basic Linux"

The README includes:
- Overview of the sessions
- List of presenters
- Session date